### PR TITLE
added ulimits to docker compose

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -30,6 +30,10 @@ services:
       - "6064:4064"
     volumes:
       - "omero:/OMERO"
+    ulimits:
+      nofile:
+        soft: 8192
+        hard: 65536
 
   omeroweb:
     # This container uses the tag for the latest web release of OMERO 5


### PR DESCRIPTION
## Description

This adds `ulimits` to the tests docker-compose aligning it with https://github.com/ome/omero-test-infra/pull/81


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

