### PR TITLE
using setuptools-scm instead of setuptools-git-versioning

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -2,7 +2,7 @@ name: Release to PyPI
 
 on:
   release:
-    types: [released]
+    types: [published]
 
 jobs:
   release:

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -10,7 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
-requires = ["setuptools>=41", "setuptools-git-versioning>=2.0,<3"]
+[build-system]
+requires = ["setuptools>=80", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
-
-[tool.setuptools-git-versioning]
-enabled = true
+[tool.setuptools_scm]
 
 [project]
+
 name = "ezomero"
 dynamic = ["version"]
 maintainers = [


### PR DESCRIPTION
## Description

Changing the tool used for dynamic versioning for simplicity and functionality.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

