### PR TITLE
Update for omero-py 5.22.0: py310, numpy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@ description = "A suite of convenience functions for working with OMERO."
 readme = "README.md"
 license = "GPL-2.0"
 dependencies = [
-    "omero-py >= 5.13.0, <= 5.22.0",
-    "numpy >= 1.22, < 2.0"
+    "omero-py >= 5.22.0",
+    "numpy >= 2, < 3.0"
     ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 tables = ["pandas"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ description = "A suite of convenience functions for working with OMERO."
 readme = "README.md"
 license = "GPL-2.0"
 dependencies = [
-    "omero-py >= 5.22.0",
+    "omero-py >= 5.22.0, < 6.0",
     "numpy >= 2, < 3.0"
     ]
 requires-python = ">=3.10"


### PR DESCRIPTION
## Description
Closes: https://github.com/erickmartins/ezomero/issues/2

omero-py 0.5.22 dropped support for py39 and numpy < 2

omero-py 0.5.22 is now the tested version for latest omero-web 5.31.0 which also required py310, see:
https://forum.image.sc/t/release-of-omero-server-5-6-17-and-omero-web-5-31-0/119308

## Checklist

N/A

## For reviewers

