### PR TITLE
Update python version for sphinx workflow

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -12,10 +12,10 @@ jobs:
     name: Sphinx docs to gh-pages
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Installing the library
         shell: bash -l {0}
         run: |

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-          python-version: '3.9'
+          python-version: '3.11'
     - name: Install Tools
       env:
         VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/upload_to_test_pypi.yml
+++ b/.github/workflows/upload_to_test_pypi.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-          python-version: '3.9'
+          python-version: '3.11'
     - name: Install Tools
       env:
         VERSION: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Description

this bumps up the Python version used on the docs-generating workflow (using Sphinx) and the publishing workflows to 3.11, given the current requirement of `python >= 3.10` for the library.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

